### PR TITLE
Update sitemap and enhance FAQ with CGV links

### DIFF
--- a/src/app/activites/canyoning/canyoning-page-client.tsx
+++ b/src/app/activites/canyoning/canyoning-page-client.tsx
@@ -100,9 +100,9 @@ const CanyoningPage = () => {
                     <Image src="/images/Canyoning/canyoning-hero-mobile.webp" alt="Personne qui pratique le canyoning" fill className=" object-cover md:hidden" priority/>
 
 
-                    <div className=" max-w-[500px] w-[95%]  flex flex-col gap-4 absolute top-1/2 left-1/2 lg:left-1/3 -translate-x-1/2 -translate-y-1/2 text-white  px-6 py-2 rounded-lg bg-black/20">
+                    <div className=" max-w-[600px] w-[95%]  flex flex-col gap-4 absolute top-1/2 left-1/2 lg:left-1/3 -translate-x-1/2 -translate-y-1/2 text-white  px-6 py-2 rounded-lg bg-black/20">
                         <h1>Canyoning à Mazamet</h1>
-                        <h2 className="!text-3xl lg:!text-4xl">Fun et fraîcheur au cœur du Tarn</h2>
+                        <h2 className="!text-3xl lg:!text-4xl">Fun et fraîcheur au cœur du Tarn.</h2>
                         <h3 className="!text-lg font-paragraphe">Une randonnée aquatique dans les gorges sauvages du Banquet, à 10 min de Mazamet.</h3>
                     </div>
                     <MarkerLineSvg className="absolute -bottom-13 left-1/2 -translate-x-1/2 w-[135vw] h-24 text-white rotate-180" preserveAspectRatio="none" />

--- a/src/app/activites/escalade/escalade-page-client.tsx
+++ b/src/app/activites/escalade/escalade-page-client.tsx
@@ -98,7 +98,7 @@ const EscaladePage = () => {
         <section className="flex flex-col gap-16 items-center">
             <aside className="relative w-full h-full min-h-[800px] overflow-x-clip mb-16">²
                 <Image src="/images/escalade/Occitanie-evasion-escalade-Hero.webp" alt="Escalade en milieu naturel" fill className="object-cover" />
-                <div className="max-w-[500px] w-[95%]  flex flex-col gap-4 absolute top-1/2 left-1/2 lg:left-1/3 -translate-x-1/2 -translate-y-1/2 text-white px-6 py-2 rounded-lg bg-black/20">
+                <div className="max-w-[600px] w-[95%]  flex flex-col gap-4 absolute top-1/2 left-1/2 lg:left-1/3 -translate-x-1/2 -translate-y-1/2 text-white px-6 py-2 rounded-lg bg-black/20">
                     <h1>Escalade en Occitanie</h1>
                     <h2 className="!text-3xl lg:!text-4xl">Grimpez sur les plus belles falaises de l&apos;Aude et de l&apos;Hérault !</h2>
                     <p className="text-lg">Accessible à tous dès 6 ans, l&apos;escalade en milieu naturel est un sport complet alliant physique et mental au cœur de la nature.</p>

--- a/src/app/activites/speleologie/speleologie-page-client.tsx
+++ b/src/app/activites/speleologie/speleologie-page-client.tsx
@@ -96,10 +96,10 @@ const SpeleoPage = () => {
             <section className="flex flex-col gap-8 items-center">
                 <aside className="relative w-full h-full min-h-[800px] overflow-x-clip mb-16">
                     <Image src="/images/speleologie/speleologie-hero.webp" alt="Spéléologie" fill className="object-cover" />
-                    <div className="max-w-[500px] w-90% min-w-[350px]  flex flex-col gap-4 absolute top-1/2 left-1/2 lg:left-1/3 -translate-x-1/2 -translate-y-1/2 text-white  px-6 py-2 rounded-lg bg-black/20">
-                        <h1>Spéléologie dans l&apos;Aude</h1>
-                        <h2 className="!text-3xl lg:!text-4xl">Explorez les grottes de la Montagne Noire !</h2>
-                        <h3 className="!text-lg font-paragraphe">Découvrez les merveilles souterraines de Cabrespine et des cavités sauvages d&apos;Occitanie.</h3>
+                    <div className="max-w-[600px] w-90% min-w-[350px]  flex flex-col gap-4 absolute top-1/2 left-1/2 lg:left-1/3 -translate-x-1/2 -translate-y-1/2 text-white  px-6 py-2 rounded-lg bg-black/40">
+                        <h1 >Spéléologie dans l&apos;Aude</h1>
+                        <h2 className="!text-3xl lg:!text-4xl">Vivez une aventure souterraine encadrée, accessible et inoubliable.</h2>
+                        <h3 className="!text-lg font-paragraphe">Explorez, dès 5 ans, les grottes de la Montagne Noire, de la Haute Vallée de l&apos;Aude et des Gorges de Galamus.</h3>
                     </div>
                     <MarkerLineSvg className="absolute -bottom-13 left-1/2 -translate-x-1/2 w-[135vw] h-24 text-white rotate-180" preserveAspectRatio="none" />
                 </aside>

--- a/src/app/cgv/layout.tsx
+++ b/src/app/cgv/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+import { pageMetadata } from '@/lib/metadata-helpers';
+
+export const metadata: Metadata = pageMetadata({
+  title: 'Conditions generales de vente',
+  description:
+    'Conditions generales de vente, assurance et responsabilite - Occitanie Evasion, activites de plein air en Occitanie.',
+  path: '/cgv',
+  keywords:
+    'CGV, conditions generales de vente, annulation, remboursement, assurance, responsabilite, canyoning, Occitanie Evasion',
+});
+
+export default function CgvLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/cgv/page.tsx
+++ b/src/app/cgv/page.tsx
@@ -1,0 +1,271 @@
+import Link from 'next/link';
+import CustomSection from '@/components/layout/Section';
+import { businessInformation } from '@/config/business-information';
+
+const toc = [
+  { id: 'cgv', label: 'CGV' },
+  { id: 'annulation', label: 'Annulation et remboursement' },
+  { id: 'horaires', label: 'Horaires et retards' },
+  { id: 'diplomes', label: 'Diplomes et statuts legaux' },
+  { id: 'assurance-responsabilite', label: 'Assurance et responsabilite' },
+  { id: 'assurances', label: 'Assurances' },
+  { id: 'risques', label: 'Gestion des risques' },
+  { id: 'contre-indications', label: 'Contre-indications' },
+] as const;
+
+const CgvPage = () => {
+  const { name } = businessInformation;
+  const siteUrl = 'https://www.occitanie-evasion.com';
+
+  return (
+    <>
+      <CustomSection className="pt-32 pb-14 bg-gradient-to-br from-primary via-primary/95 to-primary/85 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-secondary mb-4">
+            Conditions g{'\u00e9'}n{'\u00e9'}rales de vente
+          </h1>
+          <p className="text-lg text-white/90 max-w-2xl mx-auto">
+            Conditions g{'\u00e9'}n{'\u00e9'}rales de vente, d&apos;assurance et de responsabilit
+            {'\u00e9'} {'\u2014'} {name}
+          </p>
+        </div>
+      </CustomSection>
+
+      <CustomSection className="py-12 md:py-16">
+        <div className="container mx-auto px-4 max-w-4xl">
+          <nav
+            aria-label="Sommaire des conditions generales"
+            className="mb-10 p-6 bg-secondary rounded-xl shadow-lg"
+          >
+            <h2 className="text-lg font-semibold text-white mb-4">Sommaire</h2>
+            <ol className="grid sm:grid-cols-2 gap-2 list-decimal list-inside text-white marker:text-white/80">
+              {toc.map((item) => (
+                <li key={item.id} className="text-white">
+                  <a
+                    href={`#${item.id}`}
+                    className="text-white hover:text-white/90 hover:underline font-medium"
+                  >
+                    {item.label}
+                  </a>
+                </li>
+              ))}
+            </ol>
+          </nav>
+
+          <div className="space-y-10 text-gray-700 leading-relaxed">
+            <section id="cgv" className="scroll-mt-28">
+              <h2 className="text-2xl font-bold text-gray-900 mb-4 pb-2 border-b-2 border-secondary/30">
+                CGV
+              </h2>
+              <p>
+                Le souscripteur r{'\u00e9'}servant pour d&apos;autres participants certifie que tous les
+                participants, ou responsables l{'\u00e9'}gaux pour les mineurs, ont pris connaissance des
+                conditions g{'\u00e9'}n{'\u00e9'}rales de vente suivantes de {name} et que chacun les accepte
+                individuellement.
+              </p>
+            </section>
+
+            <section id="annulation" className="scroll-mt-28">
+              <h2 className="text-2xl font-bold text-gray-900 mb-4 pb-2 border-b-2 border-secondary/30">
+                Annulation et remboursement
+              </h2>
+              <ol className="list-decimal pl-6 space-y-4">
+                <li>
+                  Pour toute annulation partielle ou totale du client signal{'\u00e9'}e dans les{' '}
+                  <strong>48 heures</strong> pr{'\u00e9'}c{'\u00e9'}dant l&apos;heure du d{'\u00e9'}but de la prestation, le
+                  montant total de la prestation sera d{'\u00fb'}. Aucun remboursement ne sera possible.
+                </li>
+                <li>
+                  Dans le cas d&apos;une r{'\u00e9'}servation en ligne, et si le nombre de participants ou
+                  le choix de la sortie posent un probl{'\u00e8'}me d&apos;organisation {'\u00e0'} {name},{' '}
+                  l&apos;entreprise {name} se r{'\u00e9'}serve le droit de contacter le client pour lui
+                  proposer une alternative et, le cas {'\u00e9'}ch{'\u00e9'}ant, d&apos;annuler la r{'\u00e9'}servation et de
+                  proc{'\u00e9'}der {'\u00e0'} son remboursement.
+                </li>
+                <li>
+                  Toute annulation partielle ou totale d&apos;un client, due {'\u00e0'} un cas de force
+                  majeure et sur justificatif (maladie, blessure, deuil{'\u2026'}), donnera lieu au
+                  remboursement de la personne impact{'\u00e9'}e par la circonstance emp{'\u00ea'}chant
+                  l&apos;activit{'\u00e9'}. Pour une personne mineure, {name} remboursera le montant
+                  correspondant {'\u00e0'} l&apos;inscription de l&apos;enfant et d&apos;un adulte. Le
+                  client devra alors fournir {'\u00e0'} {name} un justificatif : certificat m{'\u00e9'}dical ou acte
+                  officiel.
+                </li>
+                <li>
+                  {name} se r{'\u00e9'}serve le droit d&apos;annuler une prestation si le nombre minimum de
+                  participants {'\u00e0'} la sortie n&apos;est pas atteint pour le canyoning. Une solution
+                  sera propos{'\u00e9'}e au client pour d{'\u00e9'}caler la sortie.
+                </li>
+                <li>
+                  La d{'\u00e9'}cision d&apos;annuler une prestation en raison d&apos;un danger d{'\u00fb'} aux
+                  conditions m{'\u00e9'}t{'\u00e9'}orologiques ou aux niveaux d&apos;eau appartient au(x) guide(s) ou
+                  moniteur(s) en charge de l&apos;encadrement et de la s{'\u00e9'}curit{'\u00e9'} du groupe, et {'\u00e0'} lui
+                  seul. Cette d{'\u00e9'}cision ne peut {'\u00ea'}tre contest{'\u00e9'}e.
+                </li>
+                <li>
+                  En cas d&apos;annulation d{'\u00e9'}cid{'\u00e9'}e par {name}, toute somme pr{'\u00e9'}alablement vers{'\u00e9'}e
+                  serait int{'\u00e9'}gralement rembours{'\u00e9'}e au client.
+                </li>
+              </ol>
+            </section>
+
+            <section id="horaires" className="scroll-mt-28">
+              <h2 className="text-2xl font-bold text-gray-900 mb-4 pb-2 border-b-2 border-secondary/30">
+                Horaires et retards
+              </h2>
+              <p>
+                Suite {'\u00e0'} la r{'\u00e9'}servation, les participants recevront des informations pr{'\u00e9'}cises de lieu
+                et d&apos;heure de rendez-vous. Pour le confort des autres participants, un retard
+                de <strong>10 minutes</strong> sera tol{'\u00e9'}r{'\u00e9'}, suite {'\u00e0'} quoi le groupe partira en
+                activit{'\u00e9'} et aucun remboursement ne sera possible.
+              </p>
+            </section>
+
+            <section id="diplomes" className="scroll-mt-28">
+              <h2 className="text-2xl font-bold text-gray-900 mb-4 pb-2 border-b-2 border-secondary/30">
+                Dipl{'\u00f4'}mes et statuts l{'\u00e9'}gaux
+              </h2>
+              <div className="bg-gray-50 p-6 rounded-lg border border-gray-200">
+                <p>
+                  {name} est repr{'\u00e9'}sent{'\u00e9'}e par <strong>Florent Soum</strong>, moniteur dipl{'\u00f4'}m{'\u00e9'} BPJEPS
+                  CKDA, CS Escalade, BAPAAT Sp{'\u00e9'}l{'\u00e9'}ologie et CQP OPAH, d{'\u00e9'}clar{'\u00e9'} {'\u00e0'} l&apos;URSSAF
+                  (entreprise individuelle) et titulaire de la carte professionnelle
+                  d&apos;{'\u00e9'}ducateur sportif.
+                </p>
+                <p className="mt-2 text-sm text-gray-600">
+                  SIRET : {businessInformation.legal.siret} {'\u2014'} {businessInformation.legal.adresse}
+                </p>
+              </div>
+            </section>
+
+            <section id="assurance-responsabilite" className="scroll-mt-28">
+              <h2 className="text-2xl font-bold text-gray-900 mb-4 pb-2 border-b-2 border-secondary/30">
+                Conditions d&apos;assurance et de responsabilit{'\u00e9'}
+              </h2>
+              <p>
+                Le souscripteur r{'\u00e9'}servant pour d&apos;autres participants certifie que tous les
+                participants, ou responsables l{'\u00e9'}gaux pour les mineurs, ont pris connaissance des
+                conditions d&apos;assurance et de responsabilit{'\u00e9'} suivantes et que chacun les accepte
+                individuellement.
+              </p>
+            </section>
+
+            <section id="assurances" className="scroll-mt-28">
+              <h2 className="text-2xl font-bold text-gray-900 mb-4 pb-2 border-b-2 border-secondary/30">
+                Assurances
+              </h2>
+              <div className="space-y-4">
+                <p>
+                  {name} est couvert par une assurance de Responsabilit{'\u00e9'} Civile Professionnelle.
+                  Cette assurance couvre efficacement l&apos;ensemble des soins m{'\u00e9'}dicaux ou
+                  hospitaliers et d&apos;indemnit{'\u00e9'}s pour les risques dont le professionnel est
+                  responsable.
+                </p>
+                <p>
+                  Cependant, une assurance en responsabilit{'\u00e9'} civile individuelle couvrant les
+                  activit{'\u00e9'}s de canyoning est <strong>obligatoire</strong> pour chaque participant.
+                </p>
+                <p>
+                  En cas de r{'\u00e9'}servation avec un autre moniteur partenaire, c&apos;est
+                  l&apos;assurance de celui-ci qui sera alors sollicit{'\u00e9'}e.
+                </p>
+              </div>
+            </section>
+
+            <section id="risques" className="scroll-mt-28">
+              <h2 className="text-2xl font-bold text-gray-900 mb-4 pb-2 border-b-2 border-secondary/30">
+                Gestion des risques
+              </h2>
+              <ul className="list-disc pl-6 space-y-3">
+                <li>
+                  Les activit{'\u00e9'}s propos{'\u00e9'}es par {name} sont des aventures sportives de pleine nature.
+                  Chaque participant est conscient de s&apos;engager sur des terrains glissants et
+                  escarp{'\u00e9'}s et reconna{'\u00ee'}t le caract{'\u00e8'}re al{'\u00e9'}atoire, changeant et difficilement pr{'\u00e9'}visible
+                  du terrain de pratique et des conditions m{'\u00e9'}t{'\u00e9'}orologiques.
+                </li>
+                <li>
+                  Les participants ont acc{'\u00e8'}s sur le site{' '}
+                  <a
+                    href={siteUrl}
+                    className="text-secondary hover:underline font-medium"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {siteUrl.replace('https://', '')}
+                  </a>{' '}
+                  {'\u00e0'} tous les d{'\u00e9'}tails de l&apos;activit{'\u00e9'} dans laquelle ils s&apos;engagent. Ils
+                  doivent se renseigner attentivement et ne doivent pas sur-estimer leurs capacit{'\u00e9'}s
+                  physiques ou psychologiques ni celles de leurs enfants.
+                </li>
+                <li>
+                  Pendant l&apos;activit{'\u00e9'}, lors du briefing de s{'\u00e9'}curit{'\u00e9'} et de chaque passage de
+                  consigne, les participants doivent {'\u00ea'}tre tr{'\u00e8'}s attentifs et ne s&apos;engager que
+                  s&apos;ils ont bien compris les instructions de leur guide.
+                </li>
+                <li>
+                  {name} d{'\u00e9'}cline toute responsabilit{'\u00e9'} en cas de perte ou d{'\u00e9'}gradation d&apos;objets
+                  appartenant au client pendant l&apos;activit{'\u00e9'} : appareils photos, smartphones,
+                  cam{'\u00e9'}ras, lunettes, verres de contact, bijoux{'\u2026'} (liste non exhaustive).
+                </li>
+              </ul>
+            </section>
+
+            <section id="contre-indications" className="scroll-mt-28">
+              <h2 className="text-2xl font-bold text-gray-900 mb-4 pb-2 border-b-2 border-secondary/30">
+                Contre-indications
+              </h2>
+              <div className="space-y-4">
+                <p>
+                  Pour r{'\u00e9'}aliser les activit{'\u00e9'}s sportives propos{'\u00e9'}es par {name}, les participants ne
+                  doivent avoir aucune contre-indication m{'\u00e9'}dicale {'\u00e0'} la pratique de ces activit{'\u00e9'}s ni
+                  aucun ant{'\u00e9'}c{'\u00e9'}dent de sant{'\u00e9'} ou op{'\u00e9'}ration qui pourraient la rendre dangereuse.
+                </p>
+                <p>
+                  Les douleurs pouvant emp{'\u00ea'}cher la progression dans le canyon et sa remont{'\u00e9'}e sont
+                  consid{'\u00e9'}r{'\u00e9'}es comme contre-indications m{'\u00e9'}dicales.
+                </p>
+                <p>
+                  Un participant ayant une sp{'\u00e9'}cificit{'\u00e9'} de sant{'\u00e9'}, un handicap physique ou mental ou un
+                  traitement m{'\u00e9'}dical doit en informer {name} lors de la prise de r{'\u00e9'}servation afin
+                  que le guide puisse organiser sa prestation et offrir les meilleures conditions de
+                  confort et de s{'\u00e9'}curit{'\u00e9'}, sous r{'\u00e9'}serve que la r{'\u00e9'}servation soit accept{'\u00e9'}e par le
+                  moniteur.
+                </p>
+                <p>Il est impossible d&apos;{'\u00ea'}tre sous l&apos;effet de l&apos;alcool ou de drogue.</p>
+                <p>
+                  Les femmes enceintes sont conscientes d&apos;un risque de l{'\u00e9'}sion f{'\u0153'}tale grave ou
+                  mortelle en cas de chute ou de glissade.
+                </p>
+                <p>
+                  Pour la pratique du canyoning, les participants doivent, pour les sorties famille,
+                  {'\u00ea'}tre {'\u00e0'} l&apos;aise dans l&apos;eau et d{'\u00e9'}signer aupr{'\u00e8'}s du guide les enfants les
+                  moins {'\u00e0'} l&apos;aise.
+                </p>
+              </div>
+            </section>
+
+            <section className="border-t border-gray-200 pt-8 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+              <p className="text-sm text-gray-600">
+                Derni{'\u00e8'}re mise {'\u00e0'} jour :{' '}
+                {new Date().toLocaleDateString('fr-FR', {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                })}
+              </p>
+              <Link
+                href="/faq"
+                className="text-secondary hover:underline font-medium text-sm"
+              >
+                Retour {'\u00e0'} la FAQ {'\u2192'}
+              </Link>
+            </section>
+          </div>
+        </div>
+      </CustomSection>
+    </>
+  );
+};
+
+export default CgvPage;
+CgvPage.displayName = 'CgvPage';

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+import Link from "next/link";
 import CustomSection from "@/components/layout/Section";
 import { FaqSchema } from "@/components/layout/FaqSchema";
 import { FAQ } from "@/components/ui/FAQ";
@@ -27,6 +28,16 @@ export default function FAQPage() {
           <p className="text-xl text-gray-600 dark:text-gray-300 max-w-2xl mx-auto leading-relaxed">
             Trouvez rapidement les réponses à toutes vos questions sur nos activités de plein air.
             De la réservation à la sécurité, nous avons tout prévu pour vous accompagner.
+          </p>
+          <p className="mt-4 text-gray-600 dark:text-gray-300">
+            <Link
+              href="/cgv"
+              className="text-secondary hover:underline font-medium"
+            >
+              Conditions générales de vente (CGV)
+            </Link>
+            {" "}
+            — annulation, assurance et responsabilité.
           </p>
         </div>
       </CustomSection>

--- a/src/app/randonnee-aquatique-mazamet-tarn/layout.tsx
+++ b/src/app/randonnee-aquatique-mazamet-tarn/layout.tsx
@@ -1,0 +1,81 @@
+import type { Metadata } from 'next';
+import { pageMetadata } from '@/lib/metadata-helpers';
+import { businessInformation } from '@/config/business-information';
+
+const PAGE_PATH = '/randonnee-aquatique-mazamet-tarn';
+const PAGE_URL = `https://www.occitanie-evasion.com${PAGE_PATH}`;
+
+export const metadata: Metadata = pageMetadata({
+  title: 'Randonnee aquatique Mazamet | Canyoning gorges du Banquet (Tarn)',
+  description:
+    'Randonnee aquatique et canyoning dans les gorges du Banquet, a 10 min de Mazamet (Tarn). Sauts, toboggans, eau vive : guide diplome Occitanie Evasion.',
+  path: PAGE_PATH,
+  keywords: [
+    businessInformation.seo.keywords,
+    'randonnee aquatique mazamet',
+    'randonnee aquatique tarn',
+    'canyoning mazamet',
+    'canyoning gorges du banquet',
+    'gorges du banquet saint-amans-valtoret',
+    'canyon de l arn',
+    'activite eau vive tarn',
+    'canyoning haut languedoc',
+  ].join(', '),
+  ogImage: '/images/Og/Og-Canyoning.jpg',
+});
+
+const articleSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: 'Randonnee aquatique a Mazamet : canyoning dans les gorges du Banquet',
+  description:
+    'Guide complet pour decouvrir le canyoning et la randonnee aquatique dans les gorges du Banquet, entre Mazamet et Saint-Amans-Valtoret, dans le Tarn.',
+  author: {
+    '@type': 'Person',
+    name: 'Florent Soum',
+  },
+  publisher: {
+    '@type': 'Organization',
+    name: businessInformation.name,
+    url: 'https://www.occitanie-evasion.com',
+  },
+  mainEntityOfPage: PAGE_URL,
+  image: 'https://www.occitanie-evasion.com/images/Og/Og-Canyoning.jpg',
+};
+
+const touristSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'TouristDestination',
+  name: 'Gorges du Banquet',
+  description:
+    'Canyon de l\'Arn pour la randonnee aquatique et le canyoning, a proximite de Mazamet dans le Tarn.',
+  geo: {
+    '@type': 'GeoCoordinates',
+    latitude: 43.492,
+    longitude: 2.52,
+  },
+  containedInPlace: {
+    '@type': 'AdministrativeArea',
+    name: 'Tarn',
+  },
+};
+
+export default function RandonneeAquatiqueLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(touristSchema) }}
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/randonnee-aquatique-mazamet-tarn/page.tsx
+++ b/src/app/randonnee-aquatique-mazamet-tarn/page.tsx
@@ -1,0 +1,5 @@
+import RandonneeAquatiquePageClient from './randonnee-aquatique-mazamet-tarn-page-client';
+
+export default function RandonneeAquatiqueMazametTarnPage() {
+  return <RandonneeAquatiquePageClient />;
+}

--- a/src/app/randonnee-aquatique-mazamet-tarn/randonnee-aquatique-mazamet-tarn-page-client.tsx
+++ b/src/app/randonnee-aquatique-mazamet-tarn/randonnee-aquatique-mazamet-tarn-page-client.tsx
@@ -1,0 +1,424 @@
+"use client";
+
+import { useRef } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { easeOut, motion, useInView } from "framer-motion";
+import { MapPin, Clock, Droplets, Shield, ChevronRight } from "lucide-react";
+import { MarkerLineSvg } from "@/components/ui/svg/MarkerLine.svg";
+import { Carousel } from "@/components/ui/Carrousel";
+import { ActivityFormulas } from "@/components/ui";
+import ReservationLink from "@/components/ui/ReservationLink";
+import { GalleryInsta } from "@/components/ui/gallery";
+import { GalleryInstaArray } from "@/components/ui/gallery/galleryInsta";
+import CustomSection from "@/components/layout/Section";
+import ContactSection from "../(section-page)/contact-section";
+
+const gallery: GalleryInstaArray = [
+  { url: "/images/Canyoning/gallery/canyoning_occitanie-evasion_27.webp", alt: "Vue des gorges du Banquet depuis le canyon" },
+  { url: "/images/Canyoning/gallery/canyoning_occitanie-evasion_13.webp", alt: "Gorges du Banquet - canyon de l'Arn" },
+  { url: "/images/Canyoning/gallery/canyoning_occitanie-evasion_19.webp", alt: "Cascade dans les gorges du Banquet" },
+  { url: "/images/Canyoning/gallery/canyoning_occitanie-evasion_8.webp", alt: "Glissade en canyoning au Banquet" },
+  { url: "/images/Canyoning/gallery/canyoning_occitanie-evasion_22.webp", alt: "Saut en canyoning dans le Tarn" },
+  { url: "/images/Canyoning/gallery/canyoning_occitanie-evasion_18.webp", alt: "Toboggan naturel gorges du Banquet" },
+];
+
+const containerVariants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: { staggerChildren: 0.15, delayChildren: 0.1 },
+  },
+};
+
+const itemVariants = {
+  hidden: { opacity: 0, y: 24 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.6, ease: easeOut },
+  },
+};
+
+const leftBlockVariants = {
+  hidden: { opacity: 0, x: -40, y: 16 },
+  visible: { opacity: 1, x: 0, y: 0, transition: { duration: 0.65, ease: easeOut } },
+};
+
+const rightBlockVariants = {
+  hidden: { opacity: 0, x: 40, y: 16 },
+  visible: { opacity: 1, x: 0, y: 0, transition: { duration: 0.65, ease: easeOut } },
+};
+
+export default function RandonneeAquatiquePageClient() {
+  const introRef = useRef(null);
+  const parcoursRef = useRef(null);
+  const pratiqueRef = useRef(null);
+  const formulasRef = useRef(null);
+
+  const introInView = useInView(introRef, { once: true, margin: "-80px" });
+  const parcoursInView = useInView(parcoursRef, { once: true, margin: "-80px" });
+  const pratiqueInView = useInView(pratiqueRef, { once: true, margin: "-80px" });
+  const formulasInView = useInView(formulasRef, { once: true, margin: "-80px" });
+
+  return (
+    <div className="flex flex-col gap-16 overflow-x-clip">
+      <section className="flex flex-col gap-8 items-center">
+        <aside className="relative w-full min-h-[720px] lg:min-h-[800px] overflow-x-clip mb-16">
+          <Image
+            src="/images/Canyoning/canyoning-hero.webp"
+            alt="Randonnee aquatique et canyoning dans les gorges du Banquet, Mazamet, Tarn"
+            fill
+            className="object-cover hidden md:block"
+            priority
+          />
+          <Image
+            src="/images/Canyoning/canyoning-hero-mobile.webp"
+            alt="Canyoning gorges du Banquet pres de Mazamet"
+            fill
+            className="object-cover md:hidden"
+            priority
+          />
+          <div className="max-w-[640px] w-[95%] flex flex-col gap-3 absolute top-1/2 left-1/2 lg:left-1/3 -translate-x-1/2 -translate-y-1/2 text-white px-6 py-4 rounded-lg bg-black/25">
+            <nav aria-label="Fil d'Ariane" className="text-sm text-white/80 font-paragraphe">
+              <Link href="/" className="hover:text-secondary transition-colors">
+                Accueil
+              </Link>
+              {" / "}
+              <Link href="/activites/canyoning" className="hover:text-secondary transition-colors">
+                Canyoning
+              </Link>
+              {" / "}
+              <span className="text-white">Banquet</span>
+            </nav>
+            <h1>Randonnee aquatique a Mazamet</h1>
+            <h2 className="!text-3xl lg:!text-4xl">
+              Canyoning dans les <span className="text-secondary">gorges du Banquet</span>
+            </h2>
+            <p className="!text-lg font-paragraphe">
+              A 10 minutes de Mazamet, descendez le canyon de l&apos;Arn dans le Tarn : eau vive,
+              granit et nature sauvage du Parc naturel regional du Haut-Languedoc.
+            </p>
+            <ReservationLink
+              activity="canyoning"
+              lieux="banquet"
+              className="text-white bg-primary/90 px-5 py-2.5 rounded-lg w-fit mt-2 hover:bg-primary transition-all duration-300 font-semibold"
+            >
+              Reserver au Banquet
+            </ReservationLink>
+          </div>
+          <MarkerLineSvg
+            className="absolute -bottom-13 left-1/2 -translate-x-1/2 w-[135vw] h-24 text-white rotate-180"
+            preserveAspectRatio="none"
+          />
+        </aside>
+
+        <motion.article
+          ref={introRef}
+          className="container mx-auto space-y-16 px-6 max-w-5xl"
+          variants={containerVariants}
+          initial="hidden"
+          animate={introInView ? "visible" : "hidden"}
+        >
+          <motion.div variants={leftBlockVariants}>
+            <h2>
+              Les gorges du Banquet, spot incontournable du <span className="text-primary">Tarn</span>
+            </h2>
+            <div className="space-y-4 max-w-[850px] text-justify mt-6 font-paragraphe text-lg">
+              <p>
+                A quelques kilometres a l&apos;est de <strong>Mazamet</strong>, le village de{" "}
+                <strong>Saint-Amans-Valtoret</strong> (81240) abrite l&apos;une des plus belles
+                descentes de canyon du departement : les <strong>gorges du Banquet</strong>. Sculptees
+                dans le granit par la riviere de l&apos;<strong>Arn</strong>, ces gorges encaissees
+                offrent un decor mineral spectaculaire, entre parois verticales, vasques turquoise et
+                cascades.
+              </p>
+              <p>
+                Class{'\u00e9'}es au coeur du <strong>Parc naturel regional du Haut-Languedoc</strong>, elles
+                attirent les amateurs de <strong>randonnee aquatique</strong> et de{" "}
+                <strong>canyoning a Mazamet</strong> des le printemps, lorsque le debit de l&apos;eau
+                permet une descente ludique et rafraichissante e de mai a septembre en generale.
+              </p>
+              <p>
+                Propriete privee, le site est accessible uniquement avec un{" "}
+                <strong>guide diplome</strong>. Avec <strong>Occitanie Evasion</strong>, Florent Soum
+                vous accompagne en toute securite pour vivre cette aventure en eau vive, que vous
+                la decouvriez en demi-journee ou sur la journee complete.
+              </p>
+            </div>
+          </motion.div>
+
+          <motion.div variants={rightBlockVariants} className="flex justify-end">
+            <div className="space-y-4 max-w-[850px] text-justify font-paragraphe text-lg">
+              <h2>
+                Randonnee aquatique ou canyoning :<span className="text-primary"> quelle difference ?</span>
+              </h2>
+              <p>
+                Sur le terrain, c&apos;est la meme experience : une progression dans le cours d&apos;eau,
+                en combinaison neoprene et casque. On marche, on nage, on glisse sur des toboggans
+                naturels et on franchit les obstacles aux cotes de son moniteur.
+              </p>
+              <p>
+                Le terme <strong>randonnee aquatique</strong> est souvent recherche par les familles
+                et les debutants autour de <strong>Mazamet</strong> ; le mot <strong>canyoning</strong>{" "}
+                evoque davantage les sensations fortes. Au Banquet, les deux se rejoignent : parcours
+                accessible des <strong>10 ans</strong>, sauts toujours <strong>optionnels</strong>, et
+                ambiance conviviale.
+              </p>
+              <p>
+                <Link href="/activites/canyoning" className="text-secondary font-semibold hover:underline">
+                  Voir la page canyoning Occitanie Evasion
+                </Link>{" "}
+                pour l&apos;ensemble des informations sur l&apos;activite.
+              </p>
+            </div>
+          </motion.div>
+        </motion.article>
+
+        <motion.article
+          ref={parcoursRef}
+          className="w-full bg-primary py-16 px-6 relative"
+          variants={itemVariants}
+          initial="hidden"
+          animate={parcoursInView ? "visible" : "hidden"}
+        >
+          <MarkerLineSvg
+            className="absolute -top-13 left-1/2 -translate-x-1/2 w-[135vw] h-24 text-white"
+            preserveAspectRatio="none"
+          />
+          <div className="container mx-auto max-w-5xl text-white space-y-8">
+            <h2 className="text-center text-white">
+              Que vivre dans le canyon du <span className="text-secondary">Banquet</span> ?
+            </h2>
+            <div className="grid md:grid-cols-2 gap-8 font-paragraphe text-lg">
+              <div className="space-y-4">
+                <h3 className="!text-2xl text-secondary">Partie haute e demi-journee</h3>
+                <p>
+                  La portion amont des gorges concentre les passages les plus encaisses : enchainement
+                  de <strong>sauts jusqu&apos;a 6 ou 7 metres</strong> (contournables),{" "}
+                  <strong>toboggans naturels</strong>, nages dans les vasques et marche le long des
+                  parois de granit. Comptez environ <strong>3 heures</strong> d&apos;activite, equipement
+                  compris.
+                </p>
+              </div>
+              <div className="space-y-4">
+                <h3 className="!text-2xl text-secondary">Integral e journee</h3>
+                <p>
+                  La formule journee permet de descendre <strong>l&apos;integralite des gorges du Banquet</strong>{" "}
+                  : matinee dynamique dans le haut du canyon, pause pique-nique sur les rochers, puis
+                  apres-midi tres ludique avec toboggans a refaire, baignades et final memorable. Environ{" "}
+                  <strong>5 heures</strong> sur le terrain.
+                </p>
+              </div>
+            </div>
+            <ul className="grid sm:grid-cols-3 gap-4 pt-4">
+              {[
+                { icon: Droplets, label: "Eau vive de l'Arn", text: "Rafraichissement garanti en ete" },
+                { icon: Shield, label: "Encadrement pro", text: "BPJEPS, materiel aux normes" },
+                { icon: MapPin, label: "10 min de Mazamet", text: "RDV au Banquet, 81240" },
+              ].map(({ icon: Icon, label, text }) => (
+                <li
+                  key={label}
+                  className="bg-white/10 rounded-lg p-4 flex flex-col gap-2"
+                >
+                  <Icon className="w-8 h-8 text-secondary" aria-hidden />
+                  <strong>{label}</strong>
+                  <span className="text-white/90 text-base">{text}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </motion.article>
+
+        <motion.div
+          className="w-full flex flex-col gap-6 items-center min-h-[480px] relative px-4"
+          variants={itemVariants}
+          initial="hidden"
+          animate={parcoursInView ? "visible" : "hidden"}
+        >
+          <div className="absolute w-[90%] min-h-[180px] bottom-16 left-1/2 -translate-x-1/2 lg:translate-x-0 lg:h-full lg:w-1/3 lg:top-0 lg:left-4 z-50">
+            <div className="w-full h-full bg-white/30 p-4 rounded-lg flex flex-col justify-center px-8 gap-2">
+              <p className="text-white/90 font-title text-2xl lg:text-3xl font-bold">
+                Pret pour l&apos;aventure ?
+              </p>
+              <p className="text-white font-title text-3xl lg:text-5xl">
+                Le Banquet vous attend <span className="text-primary">!</span>
+              </p>
+              <ReservationLink
+                activity="canyoning"
+                lieux="banquet"
+                className="text-white bg-primary/80 px-4 py-2 rounded-lg w-fit mt-4 hover:bg-primary transition-all"
+              >
+                Reserver
+              </ReservationLink>
+            </div>
+          </div>
+          <Carousel
+            slidesToShow={1}
+            autoPlay
+            showDots
+            showArrows={false}
+            showPlayPause={false}
+            markerLineSvg
+            markerLineSvgColor="white"
+            className="w-full h-full"
+          >
+            <div className="w-full h-[600px] lg:h-[700px] relative">
+              <Image
+                src="/images/Canyoning/carrousel/canyoning_occitanie-evasion_1920_9.webp"
+                alt="Canyoning dans les gorges du Banquet, Mazamet"
+                fill
+                className="object-cover"
+              />
+            </div>
+            <div className="w-full h-[600px] lg:h-[700px] relative">
+              <Image
+                src="/images/Canyoning/carrousel/canyoning_occitanie-evasion_1920_21.webp"
+                alt="Toboggan naturel canyon du Banquet Tarn"
+                fill
+                className="object-cover"
+              />
+            </div>
+            <div className="w-full h-[600px] lg:h-[700px] relative">
+              <Image
+                src="/images/Canyoning/carrousel/canyoning_occitanie-evasion_1920_31.webp"
+                alt="Randonnee aquatique gorges du Banquet"
+                fill
+                className="object-cover"
+              />
+            </div>
+          </Carousel>
+        </motion.div>
+
+        <motion.article
+          ref={pratiqueRef}
+          className="container mx-auto px-6 max-w-5xl space-y-10"
+          variants={containerVariants}
+          initial="hidden"
+          animate={pratiqueInView ? "visible" : "hidden"}
+        >
+          <motion.div variants={itemVariants}>
+            <h2>
+              Qui peut faire une randonnee aquatique au <span className="text-primary">Banquet</span> ?
+            </h2>
+            <div className="grid lg:grid-cols-2 gap-8 mt-6 font-paragraphe text-lg">
+              <div className="space-y-3">
+                <p>
+                  <strong>A partir de 10 ans</strong> en formule decouverte, avec un adulte responsable
+                  pour les mineurs. Savoir <strong>nager 25 metres</strong> et accepter de passer la tete
+                  sous l&apos;eau sont indispensables.
+                </p>
+                <p>
+                  Une condition physique correcte est necessaire : marche sur terrain pentu et rocheux,
+                  quelques passages ou il faut se hisser. Poids maximum : <strong>115 kg</strong>.
+                </p>
+                <p>
+                  Les sauts restent <strong>facultatifs</strong> : le guide propose des contournements
+                  pour progresser a son rythme.
+                </p>
+              </div>
+              <div className="bg-primary/10 rounded-xl p-6 space-y-4">
+                <h3 className="!text-xl text-primary flex items-center gap-2">
+                  <Clock className="w-5 h-5" aria-hidden />
+                  Infos pratiques Mazamet / Banquet
+                </h3>
+                <ul className="space-y-2 font-semibold">
+                  <li>
+                    <strong>Saison :</strong> mai a septembre (selon meteo et debit)
+                  </li>
+                  <li>
+                    <strong>Rendez-vous :</strong> Le Banquet, 81240 Saint-Amans-Valtoret
+                  </li>
+                  <li>
+                    <strong>Horaires :</strong> 10h (matin) / 14h30 (apres-midi demi-journee) / 10h30
+                    (journee)
+                  </li>
+                  <li>
+                    <strong>Equipement fourni :</strong> combinaison, casque, sac etanche
+                  </li>
+                  <li>
+                    <strong>A prevoir :</strong> maillot, chaussures de marche, eau, crene solaire
+                  </li>
+                </ul>
+                <p className="text-sm">
+                  Consultez nos{" "}
+                  <Link href="/cgv" className="text-secondary hover:underline">
+                    conditions generales de vente
+                  </Link>{" "}
+                  et la{" "}
+                  <Link href="/faq" className="text-secondary hover:underline">
+                    FAQ
+                  </Link>{" "}
+                  pour l&apos;annulation et l&apos;assurance.
+                </p>
+              </div>
+            </div>
+          </motion.div>
+
+          <motion.div variants={itemVariants} className="bg-secondary/10 rounded-xl p-8 border-l-4 border-secondary">
+            <h2 className="!text-3xl">
+              Pourquoi descendre le Banquet avec <span className="text-secondary">Occitanie Evasion</span> ?
+            </h2>
+            <p className="mt-4 font-paragraphe text-lg text-justify">
+              Florent Soum, <strong>moniteur diplome d&apos;Etat</strong> (BPJEPS CKDA, CS Escalade,
+              BAPAAT Speleologie), connait intimement ce canyon. Il adapte le rythme du groupe, veille
+              a la securite a chaque obstacle et partage sa passion du territoire mazametain. Materiel
+              professionnel, petits groupes, pedagogue et bonne humeur : autant de raisons de confier
+              votre <strong>randonnee aquatique dans le Tarn</strong> a une structure locale, basee a La
+              Redorte et active sur Mazamet, l&apos;Aude et l&apos;Herault.
+            </p>
+            <Link
+              href="/reservation?activity=canyoning&lieux=banquet"
+              className="inline-flex items-center gap-2 mt-6 text-primary font-bold hover:text-secondary transition-colors"
+            >
+              Choisir une date au Banquet
+              <ChevronRight className="w-5 h-5" aria-hidden />
+            </Link>
+          </motion.div>
+        </motion.article>
+
+        <motion.div
+          ref={formulasRef}
+          className="w-full flex flex-col gap-6 items-center px-4"
+          variants={itemVariants}
+          initial="hidden"
+          animate={formulasInView ? "visible" : "hidden"}
+        >
+          <h2 className="text-center">
+            Formules canyoning <span className="text-primary">gorges du Banquet</span>
+          </h2>
+          <p className="text-center max-w-2xl font-paragraphe text-lg px-4">
+            Demi-journee ou journee complete au depart de Mazamet e tarifs 2025 sur la page canyoning.
+          </p>
+          <ActivityFormulas
+            activityName="Canyoning"
+            description_half="Partie haute du canyon du Banquet : sauts (jusqu'a 6/7 m), nages, cascades et toboggans dans la section la plus encaissee des gorges. Environ 3 h d'aventure au coeur du Tarn."
+            description_full="Descente integrale des gorges du Banquet : matinee technique et ludique, pause pique-nique, apres-midi toboggans et vasques. Une journee complete pour decouvrir tout le canyon de l'Arn."
+            reducedPriceConditions="Tarif reduit enfants jusqu'a 17 ans et groupes de 7 personnes minimum."
+            ACMPriceConditions="Tarif ACM : 8 enfants + 1 animateur = 280 EUR. Me contacter pour les disponibilites."
+          />
+        </motion.div>
+
+        <CustomSection
+          className="flex flex-col items-center justify-center w-full bg-gray-100 py-24"
+          Markercolor="white"
+          TopMarker
+        >
+          <h2 className="text-center px-4">
+            Le Banquet en images <span className="text-secondary">!</span>
+          </h2>
+          <p className="text-center max-w-xl px-4 mt-2 font-paragraphe text-gray-700">
+            Quelques souvenirs de descentes dans les gorges, entre Mazamet et Saint-Amans-Valtoret.
+          </p>
+          <GalleryInsta
+            gallery={gallery}
+            className="lg:px-16 px-4 py-12"
+            backgroundColor="gray-100"
+          />
+        </CustomSection>
+      </section>
+
+      <ContactSection />
+    </div>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -12,6 +12,12 @@ const extraRoutes: {
   { path: '/reservation', priority: 0.9, changeFrequency: 'weekly' },
   { path: '/mention-legal', priority: 0.3, changeFrequency: 'monthly' },
   { path: '/politique-de-confidentialite', priority: 0.3, changeFrequency: 'monthly' },
+  { path: '/cgv', priority: 0.3, changeFrequency: 'monthly' },
+  {
+    path: '/randonnee-aquatique-mazamet-tarn',
+    priority: 0.75,
+    changeFrequency: 'monthly',
+  },
 ];
 
 export default function sitemap(): MetadataRoute.Sitemap {

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -127,6 +127,13 @@ const Footer = () => {
                         >
                             Politique de confidentialité
                         </Link>
+                        <Link 
+                            href="/cgv" 
+                            className={cn(FooterLinkClassName)}
+                            aria-label="Consulter les conditions générales de vente"
+                        >
+                            CGV
+                        </Link>
                     </nav>
                 </div>
             </div>

--- a/src/components/ui/FAQ.tsx
+++ b/src/components/ui/FAQ.tsx
@@ -1,8 +1,72 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
+import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { FAQCategory, FAQItem, faqData } from "@/data/faq";
+
+const cgvLink = (anchor: string, label: string) => (
+  <Link
+    href={`/cgv#${anchor}`}
+    className="text-secondary hover:underline font-medium"
+  >
+    {label}
+  </Link>
+);
+
+const faqAnswersWithLinks: Partial<Record<string, ReactNode>> = {
+  "reservation-4": (
+    <>
+      Les conditions d&apos;annulation et de remboursement sont détaillées dans nos{" "}
+      {cgvLink("annulation", "conditions générales de vente")}. En résumé : annulation signalée
+      dans les 48 h avant le début de la prestation — montant dû ; force majeure sur justificatif
+      — remboursement possible ; annulation météo par le guide — report ou remboursement intégral.
+      Contactez-moi pour toute modification de réservation.
+    </>
+  ),
+  "securite-3": (
+    <>
+      La sécurité est ma priorité. En cas de conditions météorologiques ou niveaux d&apos;eau
+      dangereux, le guide peut annuler la prestation (voir{" "}
+      {cgvLink("annulation", "annulation et remboursement")}). Je propose un report ou un
+      remboursement intégral selon les cas définis dans nos CGV. Je surveille les conditions et
+      vous contacte si nécessaire.
+    </>
+  ),
+  "securite-4": (
+    <>
+      Oui, je suis entièrement assuré en Responsabilité Civile Professionnelle. Chaque participant
+      doit disposer d&apos;une assurance responsabilité civile individuelle couvrant le canyoning —
+      voir la section{" "}
+      {cgvLink("assurances", "assurances")} de nos conditions. En cas de réservation avec un
+      moniteur partenaire, c&apos;est son assurance qui s&apos;applique.
+    </>
+  ),
+  "securite-5": (
+    <>
+      Consultez les{" "}
+      {cgvLink("contre-indications", "contre-indications")} dans nos CGV : pas de contre-indication
+      médicale, poids maximum 115 kg, pas d&apos;alcool ni de drogue, femmes enceintes informées
+      des risques. Pour le canyoning, être à l&apos;aise dans l&apos;eau (sorties famille) et
+      signaler les enfants les moins à l&apos;aise au guide.
+    </>
+  ),
+  "saison-3": (
+    <>
+      Non, j&apos;adapte les activités aux conditions météo. La décision d&apos;annuler pour
+      danger météo ou niveaux d&apos;eau appartient au guide et ne peut être contestée (
+      {cgvLink("annulation", "voir CGV")}). Report ou remboursement selon les conditions prévues.
+    </>
+  ),
+  "activites-1": (
+    <>
+      Le canyoning est accessible à partir de 10 ans. La nage est obligatoire (savoir nager 25 m et
+      s&apos;immerger). Les sauts sont optionnels. Bonne forme physique requise. Voir aussi les{" "}
+      {cgvLink("contre-indications", "contre-indications")} et la gestion des{" "}
+      {cgvLink("risques", "risques")}.
+    </>
+  ),
+};
 
 interface FAQProps {
   className?: string;
@@ -49,9 +113,9 @@ const FAQItemComponent = ({ item, isOpen, onToggle }: FAQItemProps) => {
         )}
       >
         <div className="pb-4 px-0">
-          <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-            {item.answer}
-          </p>
+          <div className="text-gray-600 dark:text-gray-300 leading-relaxed">
+            {faqAnswersWithLinks[item.id] ?? item.answer}
+          </div>
         </div>
       </div>
     </div>

--- a/src/data/faq.ts
+++ b/src/data/faq.ts
@@ -35,7 +35,7 @@ export const faqData: FAQCategory[] = [
       {
         id: "reservation-4",
         question: "Puis-je annuler ma réservation ?",
-        answer: "Les annulations sont possibles jusqu'à 24h avant l'activité. En cas de météo défavorable, je propose un report gratuit. Contactez-moi directement pour toute modification."
+        answer: "Les conditions d'annulation et de remboursement sont détaillées dans nos conditions générales de vente (CGV). Annulation dans les 48 h avant la prestation : montant dû. Force majeure sur justificatif : remboursement possible. Annulation météo par le guide : report ou remboursement. Contactez-moi pour toute modification."
       },
       {
         id: "reservation-5",


### PR DESCRIPTION
- Added new routes to the sitemap for '/cgv' and '/randonnee-aquatique-mazamet-tarn' with specified priorities and change frequencies.
- Updated Canyoning, Escalade, and Spéléologie pages to increase the maximum width of content containers for better layout.
- Enhanced FAQ section by integrating links to conditions générales de vente (CGV) for relevant questions, improving user access to important information.